### PR TITLE
Fix confirmation time set on order payment capture

### DIFF
--- a/src/Order/Order.php
+++ b/src/Order/Order.php
@@ -523,7 +523,7 @@ class Order extends DataObject
      */
     public function paymentCaptured(Payment $payment, ServiceResponse $response): void
     {
-        $this->ConfirmationTime = DBDatetime::now();
+        $this->ConfirmationTime = DBDatetime::now()->getValue();
         $this->IsCart = false;
         $this->write();
 


### PR DESCRIPTION
Note: cannot add test to prevent regression, as there's no documented way to test omnipay payments with dummy gateway in `silverstripe/silverstripe-omnipay`.