### PR TITLE
Add required method from abstract

### DIFF
--- a/tests/DataObjects/TestProduct.php
+++ b/tests/DataObjects/TestProduct.php
@@ -82,4 +82,16 @@ class TestProduct extends DataObject implements PurchasableInterface
     {
         return FieldList::create();
     }
+
+    /**
+     * Unit price with additions from modules
+     * @return DBPrice
+     */
+    public function getPrice(): DBPrice
+    {
+        /** @var DBPrice $price */
+        $price = $this->dbObject('Price');
+
+        return $price;
+    }
 }


### PR DESCRIPTION
This is not a fix to ensure tests pass - it simply allows other tests to run as it builds the test manifest.

Uses the docblock @var so PHPStorm doesn't complain